### PR TITLE
Fix date range not correctly parsing start date

### DIFF
--- a/text_pastry.py
+++ b/text_pastry.py
@@ -908,6 +908,10 @@ class TextPastryDateRangeCommand(sublime_plugin.TextCommand):
             if fmt and '%' in fmt:
                 date_format = fmt
         if date is None:
+            # try to see if text is a date
+            if text:
+                date = self.parse_date(text)
+        if date is None:
             s = None
             # check if selection is a date
             if selection_count == 1:


### PR DESCRIPTION
If the start date is in a different format than the one in the regex in line 904, the start date will not be taken, which is not correct, it should be taken and parsed from text.